### PR TITLE
Fix the "not loading latest" bug

### DIFF
--- a/app/builtin-pages/com/editor/file-tree.js
+++ b/app/builtin-pages/com/editor/file-tree.js
@@ -269,10 +269,9 @@ async function onClickNode (e, fileTree, node) {
 
   if (node.isContainer) {
     node.isExpanded = !node.isExpanded
+    await node.readData()
+    fileTree.rerender()
   }
-  
-  await node.readData({ignoreCache: true})
-  fileTree.rerender()
 }
 
 function onContextmenuNode (e, fileTree, node) {

--- a/app/builtin-pages/com/editor/file-tree.js
+++ b/app/builtin-pages/com/editor/file-tree.js
@@ -269,9 +269,10 @@ async function onClickNode (e, fileTree, node) {
 
   if (node.isContainer) {
     node.isExpanded = !node.isExpanded
-    await node.readData()
-    fileTree.rerender()
   }
+  
+  await node.readData({ignoreCache: true})
+  fileTree.rerender()
 }
 
 function onContextmenuNode (e, fileTree, node) {

--- a/app/builtin-pages/com/editor/models.js
+++ b/app/builtin-pages/com/editor/models.js
@@ -13,7 +13,7 @@ var active
 export const load = async function load (file) {
   try {
     // load the file content
-    await file.readData()
+    await file.readData({ignoreCache: true})
 
     // setup the model
     let model = monaco.editor.createModel(file.preview, null, monaco.Uri.parse(file.url))

--- a/app/builtin-pages/views/editor.js
+++ b/app/builtin-pages/views/editor.js
@@ -120,7 +120,7 @@ function render () {
     document.querySelector('.editor-tabs'),
     yo`
       <div class="editor-tabs">
-        ${models.getModels().map(model => renderTabs(model))}
+        ${models.getModels().map(model => renderTab(model))}
       </div>
     `
   )
@@ -143,7 +143,7 @@ window.addEventListener('update-editor', render)
 window.addEventListener('model-dirtied', render)
 window.addEventListener('model-cleaned', render)
 
-function renderTabs (model) {
+function renderTab (model) {
   let cls = models.getActive() === model ? 'active' : ''
   return yo`
     <div draggable="true" class="tab ${cls}" onclick=${() => models.setActive(model)}>


### PR DESCRIPTION
Turns out I was right about the cause but looking at the wrong spot. The file-tree's "onClickNode" handler was correct: it only needs to read data if a container (folder) because the filetree is only concerned with the folder structure. The place that wasn't ignoring cache was in models.js, which is where the editor's buffers are managed.